### PR TITLE
Preview Emails with letter_opener

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # Preview sent email in the browser instead of sending
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -239,6 +243,7 @@ DEPENDENCIES
   dotenv-rails
   font-awesome-sass
   jbuilder (~> 2.7)
+  letter_opener
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
 
   # Preview sent emails in the browser instead of sending
   config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Preview sent emails in the browser instead of sending
+  config.action_mailer.delivery_method = :letter_opener
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
### What I did
Add **letter_opener** gem to preview email in browser in Development, instead of sending it

### How to test
 - open `rails console`
 - `user = User.first`
 - `UserMailer.with(user: user).welcome.deliver_now`

### Get browser opening from WSLg
 - I had to run export `DISPLAY=:0` in the terminal after upgrading WSL to WSLg version 1.0.19
 - Before that I would get the following error  

> Unable to open X display.


### Result
![grafik](https://user-images.githubusercontent.com/2192560/122657741-97e26c80-d166-11eb-93a5-92c088c2c9fa.png)
